### PR TITLE
Tydligare namn för "spexet" som förening och uppsättning

### DIFF
--- a/stadgar.tex
+++ b/stadgar.tex
@@ -16,11 +16,11 @@
 
 \section{Syfte}
 \subsection{Syfte}
-Linköpings StudentSpex är en ideell förening där medlemmarna främst rekryteras bland studerande vid Linköpings universitet. Föreningen har som syfte att hålla spextraditionen vid liv i Linköping. Detta görs bland annat genom att sätta upp egna spex, bjuda in andra spex till Linköping och anordna resor till andra spex.
+Föreningen Linköpings StudentSpex, i fortsättningen benämnt Spexet, är en ideell förening där medlemmarna främst rekryteras bland studerande vid Linköpings universitet. Spexet har som syfte att hålla spextraditionen vid liv i Linköping. Detta görs bland annat genom att sätta upp egna spex, bjuda in andra spex till Linköping och anordna resor till andra spex.
 
 \section{Medlemskap}
 \subsection{Medlemskap}
-Medlem i Linköpings StudentSpex, i fortsättningen benämnt Spexet, är den som ansluter sig till Spexets syfte, erlägger fastställd medlemsavgift för innevarande verksamhetsår, samt tidigare har varit medlem eller arbetar i en spexdirections organisation.
+Medlem i Spexet är den som ansluter sig till Spexets syfte, erlägger fastställd medlemsavgift för innevarande verksamhetsår, samt tidigare har varit medlem eller arbetar i en spexdirections organisation.
 
 \subsection{Hedersmedlem}
 Hedersmedlem kan inväljas av spexmötet. Hedersmedlem tillkommer föreningsmedlems rättigheter men inte skyldigheter.
@@ -55,7 +55,7 @@ Spexets organisation utövas genom:
 \label{section:spexmöten}
 
 \subsection{Spexmötet}
-Spexmötet är spexets högsta beslutande organ.
+Spexmötet är Spexets högsta beslutande organ.
 
 \subsection{Rättigheter}
 Vid spexmöte har alla medlemmar närvaro-, yttrande-, förslags- och rösträtt. Spexmötet kan adjungera andra än medlemmar till sig. Med adjungerad avses i fortsättningen närvaro-, yttrande- och förslagsrätt.
@@ -90,7 +90,7 @@ Spexmötet kan besluta att befria en vald funktionär från sina uppgifter. Fyll
 Rätt att hos styrelsen begära utlysande av extra spexmöte tillkommer:
 
 \begin{itemize}
-  \item Envar av spexets revisorer
+  \item Envar av Spexets revisorer
   \item Spexdirecteuren
   \item Grupp om minst tio medlemmar
 \end{itemize}
@@ -187,11 +187,11 @@ Styrelsen åligger
 Ordföranden åligger
 
 \begin{itemize}
-  \item att representera spexet och föra dess talan
+  \item att representera Spexet och föra dess talan
   \item att leda och övervaka arbetet inom styrelsen
   \item att kalla till och leda styrelsens sammanträden
   \item att hålla kontakt med Spexets övriga funktionärer
-  \item att hålla spexets medlemmar väl informerade om Spexets verksamhet
+  \item att hålla Spexets medlemmar väl informerade om Spexets verksamhet
 \end{itemize}
 
 \subsection{Vice ordförande}
@@ -295,7 +295,7 @@ Ekonomichefen åligger:
 \end{itemize}
 
 \subsection{Arbetande personer}
-Samtliga i organisationen arbetande personer måste vara medlemmar i spexet. Spexdirectionen kan under kortare tid engagera personer som inte är medlemmar i Spexet till arbetet med uppsättningen.
+Samtliga i organisationen arbetande personer måste vara medlemmar i föreningen. Spexdirectionen kan under kortare tid engagera personer som inte är föreningsmedlemmar till arbetet med uppsättningen.
 
 \subsection{Avslutande av spex}
 Då spexdirectionens uppsättning anses nedlagd ska verksamheten snarast revideras. Spexdirectionen befrias av spexmötet från sina uppgifter då dennas spexrevision är godkänd.\newline
@@ -363,10 +363,10 @@ Avgår någon av spexmötet vald funktionär under verksamhetsperioden skall han
 \label{section:100-klubben}
 
 \subsection{Medlem}
-Medlem i Spexet som varit närvarande vid 100 stycken av Spexets föreställningar inför betalande publik blir automatiskt medlem i 100-klubben.
+Föreningsmedlem som varit närvarande vid 100 stycken av Spexets föreställningar inför betalande publik blir automatiskt medlem i 100-klubben.
 
 \subsection{Inaktiva medlemmar}
-Spexmedlem som inte är aktiv i ett års spexuppsättning eller styrelse, kan max tillgodoräkna sig två föreställningar detta år.
+Föreningsmedlem som inte är aktiv i ett års spexuppsättning eller styrelse, kan max tillgodoräkna sig två föreställningar detta år.
 
 \subsection{Medlemsbevis}
 Medlem i 100-klubben äger rätt att erhålla ett medlemsbevis. Medlemsbevisen bekostas av Spexet.
@@ -384,7 +384,7 @@ För ändring i denna stadga krävs 2/3 majoritet för ändringsförslaget på t
 
 \section{Spexets upphörande}
 \subsection{Spexets upphörande}
-Spexet skall upphöra om antalet ordinarie medlemmar understiger tolv, styrelsen oräknad, eller i det fall årsmötet med 3/4 majoritet så beslutar. Spexets tillgångar fonderas i så fall hos Linköpings Universitets Studentkårer. Fonden utbetalas till nybildad studentorganisation med spexliknande verksamhet. Spexet kan dock ej upphöra om skulderna överstiger tillgångarna. Spexmötes beslut om spexets upphörande måste ske under punkt upptagen i kallelse.
+Föreningen skall upphöra om antalet ordinarie medlemmar understiger tolv, styrelsen oräknad, eller i det fall årsmötet med 3/4 majoritet så beslutar. Föreningens tillgångar fonderas i så fall hos Linköpings Universitets Studentkårer. Fonden utbetalas till nybildad studentorganisation med spexliknande verksamhet. Föreningen kan dock ej upphöra om skulderna överstiger tillgångarna. Spexmötes beslut om spexets upphörande måste ske under punkt upptagen i kallelse.
 
 \setcounter{section}{16}
 \section{ }

--- a/stadgar.tex
+++ b/stadgar.tex
@@ -257,13 +257,13 @@ Spexdirectionen utgör ledningen för en spexuppsättning.
 \subsection{Sammansättning}
 Spexdirectionen består av en spexdirecteur och en ekonomichef.\newline
 \newline
-Om speciella omständigheter och behov så påkallar kan spexmötet besluta att spexdirectionen för en viss uppsättning skall ha en annan sammansättning.
+Om speciella omständigheter och behov så påkallar kan spexmötet besluta att spexdirectionen för en viss spexuppsättning skall ha en annan sammansättning.
 
 \subsection{Val}
-En spexdirection väljs då spexmötet finner att tiden är inne för uppstartande av ett nytt spex. Spexdirectionen är ansvarig inför spexmötet. Under en övergångsperiod kan flera spexdirectioner verka.
+En spexdirection väljs då spexmötet finner att tiden är inne för uppstartande av en ny spexuppsättning. Spexdirectionen är ansvarig inför spexmötet. Under en övergångsperiod kan flera spexdirectioner verka.
 
 \subsection{Organisationsnamn}
-Organisationen ska kallas SPEX-nn, där nn är årtalet för premiären på spexet. Om omständigheterna kräver kan annan unik benämning för uppsättningen väljas.
+Organisationen ska kallas SPEX-nn, där nn är årtalet för spexuppsättningens premiär. Om omständigheterna kräver kan annan unik benämning för uppsättningen väljas.
 
 \subsection{Teckningsrätt}
 Spexdirecteur och ekonomichef äger rätt att var för sig teckna Spexets firma i organisationens namn.
@@ -281,7 +281,7 @@ Spexdirectionen åligger
 Spexdirecteuren åligger
 
 \begin{itemize}
-  \item att på Spexmötets uppdrag uppföra ett spex enligt gängse tradition
+  \item att på Spexmötets uppdrag uppföra en spexuppsättning enligt gängse tradition
 \end{itemize}
 
 \subsection{Ekonomichef}
@@ -300,9 +300,9 @@ Samtliga i organisationen arbetande personer måste vara medlemmar i föreningen
 \subsection{Avslutande av spex}
 Då spexdirectionens uppsättning anses nedlagd ska verksamheten snarast revideras. Spexdirectionen befrias av spexmötet från sina uppgifter då dennas spexrevision är godkänd.\newline
 \newline
-Spexets räkenskaper och övriga handlingar ska vara revisorerna tillhanda senast tre veckor före det spexmöte som är det närmast påföljande fyra månader efter spexets sista föreställning.\newline
+Spexuppsättningens räkenskaper och övriga handlingar ska vara revisorerna tillhanda senast tre veckor före det spexmöte som är det närmast påföljande fyra månader efter spexetuppsättningens sista föreställning.\newline
 \newline
-Om SPEX-nn inte kan avslutas enligt denna stadga så åligger det spexdirectionen att avge en statusrapport för spexets avslutande på varje påföljande spexmöte till dess SPEX-nn kan avslutas.
+Om SPEX-nn inte kan avslutas enligt denna stadga så åligger det spexdirectionen att avge en statusrapport för spexuppsättningens avslutande på varje påföljande spexmöte till dess SPEX-nn kan avslutas.
 
 \section{Synopsisgruppen}
 \label{section:synopsisgruppen}


### PR DESCRIPTION
I nuvarande stadgar använder vi "Spexet" för hela föreningen och både "spexet" och "uppsättningen" när en uppsättning avses. Ibland skrivs även "Spexet" med litet s, och i början av meningar skrivs båda med stort S vilket gör det svårt att veta vad som menas.

Den här ändringen gör användandet av "Spexet" konsekvent igenom dokumentet, och ändrar alla förekommanden av "uppsättningen" och "spexet" (där uppsättningen avses) till "spexuppsättningen" för att göra det otvetydigt vad som menas. 

Det får även effekter som att där det förut stod "ett spex" står det nu "en spexuppsättning", vilket gör det väldigt tydligt att det är hela uppsättningen som avses och inte en enskild föreställning. Det lär inte innebära någon skillnad för oss som faktiskt är spexare och förstår vad som menas, men jag jobbar under förutsättningen att någon helt oinsatt ska kunna läsa stadgarna och ändå förstå vad som avses.